### PR TITLE
🐛 [bug fix] Fix duplicate AdbPermissionDialog

### DIFF
--- a/app/src/main/kotlin/com/bl4ckswordsman/cerberustiles/activities/OverlayActivity.kt
+++ b/app/src/main/kotlin/com/bl4ckswordsman/cerberustiles/activities/OverlayActivity.kt
@@ -19,6 +19,7 @@ import com.bl4ckswordsman.cerberustiles.SettingsUtils.Vibration.toggleVibrationM
 import com.bl4ckswordsman.cerberustiles.SettingsUtils.openPermissionSettings
 import com.bl4ckswordsman.cerberustiles.models.RingerMode
 import com.bl4ckswordsman.cerberustiles.ui.OverlayDialog
+import com.bl4ckswordsman.cerberustiles.ui.AdbPermissionDialog
 import com.bl4ckswordsman.cerberustiles.ui.OverlayDialogParams
 import com.bl4ckswordsman.cerberustiles.ui.createSharedParams
 
@@ -64,6 +65,13 @@ class OverlayActivity : ComponentActivity() {
         setContent {
             val showOverlayDialog = rememberSaveable { mutableStateOf(true) }
             val currentRingerMode by viewModel.currentRingerMode.observeAsState(RingerMode.NORMAL)
+
+            if (viewModel.showAdbDialog.value) {
+                AdbPermissionDialog(
+                    context = this,
+                    onDismiss = { viewModel.showAdbDialog.value = false }
+                )
+            }
 
             val params = OverlayDialogParams(
                 showDialog = showOverlayDialog,

--- a/app/src/main/kotlin/com/bl4ckswordsman/cerberustiles/ui/OverlayDialog.kt
+++ b/app/src/main/kotlin/com/bl4ckswordsman/cerberustiles/ui/OverlayDialog.kt
@@ -58,12 +58,6 @@ fun OverlayDialog(params: OverlayDialogParams) {
     val currentRingerMode = rememberSaveable {
         mutableStateOf(Ringer.getCurrentRingerMode(params.sharedParams.context))
     }
-    if (params.showAdbDialog) {
-        AdbPermissionDialog(
-            context = params.sharedParams.context,
-            onDismiss = params.onAdbDialogDismiss
-        )
-    }
 
     if (params.showDialog.value) {
         Dialog(onDismissRequest = {


### PR DESCRIPTION
Removed `AdbPermissionDialog` from `OverlayDialog.kt` and added it to `OverlayActivity.kt` to prevent the dialog from displaying twice when both `MainScreen` and `OverlayDialog` are triggered concurrently due to shared ViewModel states.

---
*PR created automatically by Jules for task [12731803282092541891](https://jules.google.com/task/12731803282092541891) started by @bl4ckswordsman*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved ADB permission dialog handling structure within the overlay system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->